### PR TITLE
Initial (real) timeout implementation

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -8,10 +8,7 @@ AllCops:
 LineLength:
   Max: 128
 
-Style/StringLiterals:
-  EnforcedStyle: double_quotes
-
-Style/SpaceBeforeFirstArg:
+Style/AccessorMethodName:
   Enabled: false
 
 Style/ConditionalAssignment:
@@ -20,27 +17,33 @@ Style/ConditionalAssignment:
 Style/RescueModifier:
   Enabled: false
 
+Style/SpaceBeforeFirstArg:
+  Enabled: false
+
+Style/StringLiterals:
+  EnforcedStyle: double_quotes
+
 #
 # Metrics
 #
 
-Metrics/MethodLength:
+Metrics/AbcSize:
   Max: 50
 
 Metrics/ClassLength:
   Max: 200
 
-Metrics/AbcSize:
-  Max: 25
-
 Metrics/CyclomaticComplexity:
   Max: 10
 
-Metrics/PerceivedComplexity:
-  Max: 10
+Metrics/MethodLength:
+  Max: 50
 
 Metrics/ParameterLists:
   Enabled: false
+
+Metrics/PerceivedComplexity:
+  Max: 10
 
 #
 # Lint

--- a/lib/socketry/exceptions.rb
+++ b/lib/socketry/exceptions.rb
@@ -13,6 +13,9 @@ module Socketry
   # Cannot perform operation in current state
   StateError = Class.new(Socketry::Error)
 
+  # Internal consistency error within the library
+  InternalError = Class.new(Socketry::Error)
+
   module Resolver
     # DNS resolution errors
     Error = Class.new(Socketry::AddressError)

--- a/lib/socketry/timeout.rb
+++ b/lib/socketry/timeout.rb
@@ -13,12 +13,36 @@ module Socketry
     }.freeze
 
     def start_timer(timer_class: DEFAULT_TIMER_CLASS)
+      raise InternalError, "timer already started" if @interval
+
       @interval = timer_class.new
       @interval.start
+
+      @deadline = nil
     end
 
     def lifetime
       @interval.to_f
+    end
+
+    def set_timeout(timeout)
+      raise InternalError, "deadline already set" if @deadline
+      return unless timeout
+      @deadline = @interval.to_f + timeout
+    end
+
+    def clear_timeout(timeout)
+      return unless timeout
+      raise InternalError, "no deadline set" unless @deadline
+      @deadline = nil
+    end
+
+    def time_remaining(timeout)
+      return unless timeout
+      raise InternalError, "no deadline set" unless @deadline
+      remaining = @deadline - @interval.to_f
+      raise Socketry::TimeoutError, "time expired" if remaining <= 0
+      remaining
     end
   end
 end


### PR DESCRIPTION
This implementation uses Hitimes-based counters to calculate timeouts

Timeouts are stateful per connection and can potentially run afoul of consistency errors, but there are at least runtime exceptions configured if sockets wind up in unexpected timeout states.